### PR TITLE
Force bot to respond in a thread in IM channels

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -235,7 +235,7 @@ def respond_to_new_message(
     try:
         is_in_dm_with_bot = payload.get("channel_type") == "im"
         is_no_mention_required = False
-        thread_ts = payload.get("thread_ts")
+        thread_ts = payload.get('ts') if is_in_dm_with_bot else payload.get("thread_ts")
         if is_in_dm_with_bot is False and thread_ts is None:
             return
 
@@ -351,7 +351,7 @@ def respond_to_new_message(
         wip_reply = post_wip_message(
             client=client,
             channel=context.channel_id,
-            thread_ts=payload.get("thread_ts") if is_in_dm_with_bot else payload["ts"],
+            thread_ts=thread_ts,
             loading_text=loading_text,
             messages=messages,
             user=user_id,


### PR DESCRIPTION
This PR tricks the current flow of responding in a DM with the app to clear up some of the history (at least visually) in the interface. By always passing `thread_ts` to  `post_wip_message`, we can force the bot to always reply in a thread. 

Current Flow:
- If a user is in a DM with a bot, then the bot responds as a new message, not in a thread

New Flow:
-  If a user is in a DM with a bot, then the bot responds in a thread.